### PR TITLE
Add compatibility with http.rb versions lower than 1.0.0

### DIFF
--- a/hal-client.gemspec
+++ b/hal-client.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "http", "~> 1.0.0"
+  spec.add_dependency "http", ">= 0.7", "< 2.0.0"
   spec.add_dependency "addressable", "~> 2.3"
   spec.add_dependency "multi_json", "~> 1.9"
 

--- a/lib/hal_client.rb
+++ b/lib/hal_client.rb
@@ -207,9 +207,9 @@ class HalClient
     override_headers = options[:override_headers]
 
     if !override_headers
-      @client_for_get ||= base_client.headers(default_message_request_headers)
+      @client_for_get ||= with_headers(base_client, default_message_request_headers)
     else
-      client_for_get.headers(override_headers)
+      with_headers(client_for_get, override_headers)
     end
   end
 
@@ -222,9 +222,17 @@ class HalClient
 
     if !override_headers
       @client_for_post ||=
-        base_client.headers(default_entity_and_message_request_headers)
+        with_headers(base_client, default_entity_and_message_request_headers)
     else
-      client_for_post.headers(override_headers)
+      with_headers(client_for_post, override_headers)
+    end
+  end
+
+  def with_headers(client, headers)
+    if defined?(HTTP) && defined?(HTTP::VERSION) && HTTP::VERSION >= '1.0.0'
+      client.headers(headers)
+    else
+      client.with_headers(headers)
     end
   end
 

--- a/lib/hal_client/version.rb
+++ b/lib/hal_client/version.rb
@@ -1,3 +1,3 @@
 class HalClient
-  VERSION = "3.14.0"
+  VERSION = "3.15.0"
 end


### PR DESCRIPTION
Given that version 1.0.0 of the http.rb gem dropped support for caching, but includes other niceties, it may make sense to support both versions in the interim and let the developer using the hal-client gem to choose his poison ;)

